### PR TITLE
Extending the cache decorator to support historical and currencies

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,49 +1,58 @@
 var assert = require('assert')
 var extend = require('util')._extend
+var Promise = require('bluebird')
+var concat = Array.prototype.concat.bind([]);
 
-module.exports = function cache (cacheOptions, service) {
+module.exports = function (cacheOptions, service) {
   var options
-  var defaultOptions = {
-    ttl: 24 * 1000 * 3600
-  }
   var originalFunc
   var store
 
-  assert(cacheOptions && cacheOptions.store, 'store must be provided')
-  assert(cacheOptions.store.put, 'the store must implement both get and put functions')
-  assert(cacheOptions.store.get, 'the store must implement both get and put functions')
-  assert(service && service.latest, 'the service to decorate must implement latest')
+  var method = cacheOptions.method || 'latest';
+  var defaultOptions = {
+    method: method,
+    ttl: method === 'latest' ? 24 * 1000 * 3600 : Infinity
+  }
 
   options = extend(defaultOptions, cacheOptions)
 
-  store = options.store
+  assert(options && options.store, 'store must be provided')
+  assert(options && options.method, 'method must be provided')
+  assert(options.store.put, 'the store must implement both get and put functions')
+  assert(options.store.get, 'the store must implement both get and put functions')
+  assert(service && service[options.method], 'the service to decorate must implement ' + options.method)
 
-  originalFunc = service.latest
+  store  = options.store
+  method  = options.method
+  originalFunc = service[method]
 
-  service.latest = function latest () {
+  service[method] = function () {
+    var args = Array.from(arguments)
     var now = Date.now()
 
-    return store.get()
+    return Promise.resolve(store.get.apply(store, args))
       .then(function (val) {
         if (!val || ((val.timestamp * 1000 + options.ttl) <= now)) {
-          return originalFunc.call(service)
+          return originalFunc.apply(service, args)
             .then(function (rates) {
-              return store.put(rates)
+              return Promise.resolve(store.put.apply(store, concat(rates, args)))
                 .finally(function () {
                   return rates
                 })
             }).catch(function (err) {
-            if (!val) {
-              throw err
-            }
-            // fallback to the cache value even if it has expired
-            return val
-          })
+              if (!val) {
+                throw err
+              }
+              // fallback to the cache value even if it has expired
+              return val
+            })
         } else {
           return val
         }
       })
   }
+
+  service[method]._cache = options
 
   return service
 }


### PR DESCRIPTION
Hi @kytwb and @lorenzofox3!

I love this little lib, the API is so simple elegant. Thanks!

I would like to suggest thus PR which extends the cache decorator to add cache functionally for `historical` and `currencies` too, without inducting any breaking changes.

The service can now be decorated more than once, each time for a different method with a different cache strategy:

```js
service = oxr.cache({
  method: 'latest',
  ttl: 7 * 24 * 1000 * 3600,
  store: {
    get: function () {
      return this.value
    },
    put: function (value) {
      this.value = value
      return this.value
    }
  }
}, service)

service = oxr.cache({
  method: 'historical',
  store: {
    cache: {},
    get: function (date) {
      return this.cache[date];
    },
    put: function (value, date) {
      this.cache[date] = value;
    }
  }
}, service)
```


* In order to preserve the current behavior, `method` defaults to `latest`
and `ttl` defaults to `24 * 1000 * 3600` for `latest` and `Infinity` for any other method
* You no longer have to return a promise when you're dealing with plain values
* The arguments passed to the decorated method are also available for `get` and `put`

For example, when you call:
```js
service.historical(date, query, options)
```

Get will be called with:
```js
get (date, query, options) {}
```
And `put` with:
```js
put (value, date, query, options) {}
```

* Added tests
* Updated the readme

Hope you'll consider it (:
Asaf